### PR TITLE
Gültige URL composer.json Webseite

### DIFF
--- a/contao/dca/tl_contao_bundle_creator.php
+++ b/contao/dca/tl_contao_bundle_creator.php
@@ -177,7 +177,7 @@ $GLOBALS['TL_DCA']['tl_contao_bundle_creator'] = [
             'sorting'   => true,
             'flag'      => DataContainer::SORT_INITIAL_LETTER_ASC,
             'search'    => true,
-            'eval'      => ['mandatory' => true, 'maxlength' => 255, 'tl_class' => 'w50', 'rgxp' => 'url'],
+            'eval'      => ['mandatory' => true, 'maxlength' => 255, 'tl_class' => 'w50', 'rgxp' => 'httpurl'],
             'sql'       => "varchar(255) NOT NULL default ''",
         ],
         'editRootComposer'                  => [


### PR DESCRIPTION
Anpassung der rgxp-Regel uf httpurl

Wird die Webseite ohne Protokoll (http|s://) eingegeben bricht Composer die Installation ab.

Composer:
The provided composer.json of the local package \u0022Array\u0022 does not comply with the composer.json schema!  Errors: [\u0022authors[0].homepage : Invalid URL format\u0022]

Contao Manager:
Error handling the Composer Resolver Cloud. Please try again later.